### PR TITLE
Add text for graduates and change degree_award to Ptychion.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,4 +158,9 @@ pythontex-files-*/
 # Latexian
 TSWLatexianTemp*
 
+# Pdf documents
+*.pdf
+
+# MacOs related
 *DS_Store
+

--- a/src/details.tex
+++ b/src/details.tex
@@ -3,6 +3,14 @@
 %% Στα σχόλια του κάθε πεδίου σημειώνεται σε παρενθέσεις η default τιμή του.
 %%
 
+%%
+%% Graduated flag - ελέγχει αν το κείμενο που θα εκτυπωθεί σε διάφορα σημεία
+%% του εγγράφου, αφορά πτυχιούχο ή όχι.
+\newif\ifgraduated
+%% Αν έχετε αποφοιτήσει, αφαιρέστε το σχόλιο από την παρακάτω γραμμή.
+% \graduatedtrue
+%%
+
 % Ημερομονία έκδοσης - (κενό)
 \renewcommand{\dateofissue}{01/01/1970}
 % Αριθμός ηλεκτρονικού πρωτοκόλλου - (default: 00000)
@@ -47,6 +55,20 @@
 % \renewcommand{\enrolledvia}{Nationwide Examinations}
 % Τρέχον εξάμηνο φοίτησης - (default: κενό)
 \renewcommand{\currentsemester}{1}
+
+%%
+%% Πεδία σχετικά με την περίπτωση πτυχιούχου.
+% Ημερομηνία ανακήρυξης πτυχιούχου - (default: κενό)
+\renewcommand{\graduationdate}{01/01/1970}
+% Ημερομηνία ορκωμοσίας - (default: κενό)
+\renewcommand{\pledgedate}{01/01/1970}
+% Αριθμός πτυχίου - (default: κενό)
+\renewcommand{\degreeid}{XXXX}
+% Βαθμός πτυχίου με ακρίβεια δύο δεκαδικών ψηφίων - (default: κενό)
+\renewcommand{\gpa}{X.ΥΖ}
+% Βαθμός πτυχίου ολογράφως και με ΚΕΦΑΛΑΙΑ - (default: κενό)
+\renewcommand{\gpainfull}{GPA WRITTEN IN FULL}
+%%
 
 %% Μόνο για άρρενες (προσέξτε το directive \newcommand αντί για \renewcommand)
 % Μητρώο αρρένων - (default: κενό)

--- a/src/digrades.cls
+++ b/src/digrades.cls
@@ -169,9 +169,9 @@
 
     The aforementioned student retains their student status during the current academic year {\thisyear}.
 
-    In order to obtain the degree award, an obligatory attendance of 8 semesters is required. \\[8pt]
+    In order to obtain the Ptychion, an obligatory attendance of 8 semesters is required. \\[8pt]
 
-    The detailed trancript of records is presented in the following pages and the grading scale is indicated in the footnotes.
+    The detailed transcript of records is presented in the following pages and the grading scale is indicated in the footnotes.
 
     This certificate is granted for any legal use.
 

--- a/src/digrades.cls
+++ b/src/digrades.cls
@@ -3,7 +3,7 @@
 %%
 %% =============================================================================
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{digrades}[2016/04/24 v0.1 DIT.UoA Academic Transcript in English]
+\ProvidesClass{digrades}[2016/09/25 v0.2 DIT.UoA Academic Transcript in English]
 
 \LoadClass[a4paper,oneside,11pt]{article}[2014/09/29]
 
@@ -62,6 +62,11 @@
 
 \newcommand{\studentregistrationyear}{}
 \newcommand{\thisyear}{}
+\newcommand{\graduationdate}{}
+\newcommand{\pledgedate}{}
+\newcommand{\degreeid}{}
+\newcommand{\gpa}{}
+\newcommand{\gpainfull}{}
 \newcommand{\enrolledvia}{Nationwide Examinations}
 \newcommand{\currentsemester}{}
 %% =============================================================================
@@ -142,7 +147,13 @@
         Contact Phone Number: {\contactnumber} & Electronic Reference Number: {\refnumber} \\
     \end{tabularx}}
     \rule{\textwidth}{0.5pt}
-    {\fontsize{12pt}{12pt}\selectfont Certificate of Academic Transcript (1)}
+    {\fontsize{12pt}{12pt}\selectfont
+    \ifgraduated
+      Graduate's Certificate of Academic Transcript
+    \else
+      Certificate of Academic Transcript (1)
+    \fi
+    }
 }
 %% =============================================================================
 
@@ -167,11 +178,25 @@
     \vspace{0.4cm}
     was first enrolled in the 1st semester of studies of our Department in the academic year {\studentregistrationyear}. \\[6pt]
 
-    The aforementioned student retains their student status during the current academic year {\thisyear}.
+    \ifgraduated
+      The aforementioned student during his undergraduate studies in the Department, has been taught all the listed courses below, with their
+      respective credits and has received the equivalent grades. \\[6pt]
+    \else
+      The aforementioned student retains their student status during the current academic year {\thisyear}. \\[6pt]
+    \fi
 
     In order to obtain the Ptychion, an obligatory attendance of 8 semesters is required. \\[8pt]
 
+    \ifgraduated
+      The aforementioned student has been declared a graduate as of {\graduationdate}, took their pledge on {\pledgedate} and received their
+      Ptychion with No. {\degreeid} and grade {\gpa}, ({\gpainfull}).
+    \fi
+
     The detailed transcript of records is presented in the following pages and the grading scale is indicated in the footnotes.
+
+    \ifgraduated
+      In the last column, the indication Y (Yes), N (No) demonstrates if the course grade is used GPA calculation.
+    \fi
 
     This certificate is granted for any legal use.
 
@@ -189,9 +214,19 @@
 }
 }
 
-\newenvironment{acadyear}[1][]{%
 
-    \bfseries \hspace{6mm} \underline{Academic Year {#1}} \mdseries
+%% gradesgrouping expects one argument:
+%% if graduated is set, then argument is No of semester, e.g. 1st, 2nd, 3rd, ..
+%% otherwise, the argument is the academic year, e.g. 1970-1971
+\newenvironment{gradesgrouping}[1][]{%
+
+    \bfseries \hspace{6mm}
+    \ifgraduated
+      \underline{{#1} Semester}
+    \else
+      \underline{Academic Year {#1}}
+    \fi
+    \mdseries
     \setlength\extrarowheight{5pt}
     \tabularx{\textwidth}{ m{1.5cm} m{6cm} m{2cm} m{1.3cm} m{2.5cm} m{1.7cm} X }
 }{%

--- a/src/digrades.cls
+++ b/src/digrades.cls
@@ -180,8 +180,8 @@
     was first enrolled in the 1st semester of studies of our Department in the academic year {\studentregistrationyear}. \\[6pt]
 
     \ifgraduated
-      The aforementioned student during his undergraduate studies in the Department, has been taught all the listed courses below, with their
-      respective credits and has received the equivalent grades. \\[6pt]
+      The aforementioned student during his undergraduate studies in the Department, has been taught all the courses listed below, with their
+      respective credits and has received the corresponding grades. \\[6pt]
     \else
       The aforementioned student retains their student status during the current academic year {\thisyear}. \\[6pt]
     \fi
@@ -196,7 +196,7 @@
     The detailed transcript of records is presented in the following pages and the grading scale is indicated in the footnotes.
 
     \ifgraduated
-      In the last column, the indication Y (Yes), N (No) demonstrates if the course grade is used GPA calculation.
+      In the last column, the indication Y (Yes), N (No) indicates whether the course grade is used GPA calculation.
     \fi
 
     This certificate is granted for any legal use.

--- a/src/digrades.cls
+++ b/src/digrades.cls
@@ -172,7 +172,8 @@
         }{}
         Municipality & {\studentmunicipality} & Municipality Registration Number & {\studentmunicipalitynumber} \\
         Registration Number & \textbf{\studentid} & Date of Registration & {\studentregistrationdate} \\
-        Enrolled via & {\enrolledvia} & Semester of Studies & {\currentsemester}
+        Enrolled via & {\enrolledvia} &
+          \ifgraduated \else Semester of Studies & {\currentsemester} \fi
     \end{tabularx}
     \end{center}
     \vspace{0.4cm}

--- a/src/gradeslist.tex
+++ b/src/gradeslist.tex
@@ -1,5 +1,5 @@
 \begin{grades}
-    \begin{acadyear}[1970-1971]
+    \begin{gradesgrouping}[1970-1971]
         \grade{15100083}
             {INTRODUCTION TO INFORMATICS AND TELECOMMUNICATIONS}
             {11.ΥΠΟ}
@@ -42,9 +42,9 @@
             {(Fall)1970-1971}
             {Ten (10)}
             {Y}
-    \end{acadyear}
+    \end{gradesgrouping}
     \clearpage
-    \begin{acadyear}[1971-1972]
+    \begin{gradesgrouping}[1971-1972]
         \grade{15100126}
             {SIGNALS AND SYSTEMS}
             {11.ΥΠΟ}
@@ -52,6 +52,5 @@
             {(Fall)1971-1972}
             {Five (5)}
             {Y}
-    \end{acadyear}
+    \end{gradesgrouping}
 \end{grades}
-


### PR DESCRIPTION
Added text for graduates, as reported in official document. The output can be set using the `graduated` flag in `details.tex`. 
To control the output, I've used `\newif\ifgraduated`, as described [here](http://tex.stackexchange.com/questions/5894/latex-conditional-expression). 

Additionally, changed `acadyear`, since in the official document for a graduate, these headers are changed to `1st Semester, 2nd Semester, ..`, where all courses for each semester are listed under their respective semester and the period in which each one was passed, appears in the 5th column. 

Does it look good? Or should I change sth?
